### PR TITLE
Installing wiringpi.py too

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,6 @@ setup(
     i2c and SPI""",
     long_description=open('README.md').read(),
     ext_modules = [wiringpi_module],
+    py_modules = ["wiringpi"],
     install_requires=[],
 )


### PR DESCRIPTION
Installing WiringPi-Python does not work properly, since commit WiringPi/WiringPi-Python@c93dadf7cf826878968dc49048f3b7e6f6287691, because wiringpi.py is not installed.

This patch add wiringpi.py ti the list of files to install again.
